### PR TITLE
Fix open type deserializer

### DIFF
--- a/jpo-asn-runtime/src/main/java/us/dot/its/jpo/asn/runtime/utils/XmlUtils.java
+++ b/jpo-asn-runtime/src/main/java/us/dot/its/jpo/asn/runtime/utils/XmlUtils.java
@@ -183,6 +183,11 @@ public class XmlUtils {
       }
     }
 
+    if (token == null) {
+      element.setFinishedItem(true);
+      element.setFinishedAll(true);
+    }
+
     log.trace("current token: {} name: {} index: {}, nesting: {}",
         token, pc.getCurrentName(), pc.getCurrentIndex(), pc.getNestingDepth());
 


### PR DESCRIPTION
Fixes an issue with deserializing MessageFrame types embedded in an ODE Payload.  Prevents an infinite loop when deserializing open types.